### PR TITLE
Add parquet list support

### DIFF
--- a/sparksql-scalapb/src/main/scala/scalapb/parquet/ProtoMessageConverter.scala
+++ b/sparksql-scalapb/src/main/scala/scalapb/parquet/ProtoMessageConverter.scala
@@ -3,27 +3,35 @@ package scalapb.parquet
 import com.google.protobuf.ByteString
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 import org.apache.parquet.io.api.{Binary, Converter, GroupConverter, PrimitiveConverter}
-import org.apache.parquet.schema.GroupType
+import org.apache.parquet.schema.{OriginalType, Type}
 
 import scala.collection.JavaConverters._
 import scala.language.existentials
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 
-class ProtoMessageConverter[T <: GeneratedMessage with Message[T]](cmp: GeneratedMessageCompanion[T], schema: GroupType, onEnd: T => Unit) extends GroupConverter {
+class ProtoMessageConverter[T <: GeneratedMessage with Message[T]](cmp: GeneratedMessageCompanion[T], schemat: Type, onEnd: T => Unit) extends GroupConverter {
   val fields: scala.collection.mutable.Map[FieldDescriptor, Any] = scala.collection.mutable.Map[FieldDescriptor, Any]()
 
-  val converters = schema.getFields.asScala.map {
-    t =>
-      val fd = cmp.javaDescriptor.findFieldByName(t.getName)
-      val e: (Any) => Unit = if (fd.isRepeated) addValue(fd) else setValue(fd)
-      fd.getJavaType match {
-        case JavaType.MESSAGE =>
-          new ProtoMessageConverter(cmp.messageCompanionForField(fd).asInstanceOf[GeneratedMessageCompanion[X] forSome { type X <: GeneratedMessage with Message[X]}], t.asGroupType(), e)
-        case _ =>
-          new ProtoPrimitiveConverter(fd, e)
+  private val converters =
+    schemat.asGroupType().getFields.asScala
+      .map {
+        t =>
+          val fd = cmp.javaDescriptor.findFieldByName(t.getName)
+          val e: (Any) => Unit = if (fd.isRepeated) addValue(fd) else setValue(fd)
+          t.getOriginalType match {
+            case OriginalType.LIST =>
+              new ListConverter[T](fd, e)
+            case _ => fd.getJavaType match {
+              case JavaType.MESSAGE =>
+                new ProtoMessageConverter(cmp.messageCompanionForField(fd).asInstanceOf[GeneratedMessageCompanion[X] forSome {type X <: GeneratedMessage with Message[X]}], t.asGroupType(), e)
+              case _ =>
+                new ProtoPrimitiveConverter(fd, e)
+            }
+          }
       }
-  }
+
+  def getCurrentRecord: T = cmp.fromFieldsMap(fields.toMap)
 
   private def setValue[P](fd: FieldDescriptor)(v: P): Unit = { fields(fd) = v }
 
@@ -38,21 +46,43 @@ class ProtoMessageConverter[T <: GeneratedMessage with Message[T]](cmp: Generate
   override def start(): Unit = {
     fields.clear()
   }
+}
 
-  def getCurrentRecord: T = {
-    cmp.fromFieldsMap(fields.toMap)
+class ListConverter[T <: GeneratedMessage with Message[T]](fd: FieldDescriptor, add: Any => Unit) extends GroupConverter {
+
+  private val converter = {
+    new ElementConverter(fd, add)
   }
+
+  override def start(): Unit = {}
+
+  override def end(): Unit = {}
+
+  override def getConverter(fieldIndex: Int): Converter = converter
+}
+
+class ElementConverter(fd: FieldDescriptor, add: Any => Unit) extends GroupConverter {
+  private val converter = {
+    new ProtoPrimitiveConverter(fd, add)
+  }
+
+  override def start(): Unit = {}
+
+  override def end(): Unit = {}
+
+  override def getConverter(fieldIndex: Int): Converter = converter
 }
 
 class ProtoPrimitiveConverter(fd: FieldDescriptor, add: Any => Unit) extends PrimitiveConverter {
   override def addFloat(value: Float): Unit = add(value)
 
-  override def addBinary(value: Binary): Unit = {
-    if (fd.getJavaType == JavaType.STRING) add(value.toStringUsingUTF8)
-    else if (fd.getJavaType == JavaType.ENUM) add(fd.getEnumType.findValueByName(value.toStringUsingUTF8))
-    else if (fd.getJavaType == JavaType.BYTE_STRING) add(ByteString.copyFrom(value.getBytes))
-    else throw new RuntimeException("Unexpected type")
-  }
+  override def addBinary(value: Binary): Unit =
+    fd.getJavaType match {
+      case JavaType.STRING => add(value.toStringUsingUTF8)
+      case JavaType.ENUM => add(fd.getEnumType.findValueByName(value.toStringUsingUTF8))
+      case JavaType.BYTE_STRING => add(ByteString.copyFrom(value.getBytes))
+      case _ => throw new RuntimeException("Unexpected type")
+    }
 
   override def addDouble(value: Double): Unit = add(value)
 

--- a/sparksql-scalapb/src/main/scala/scalapb/parquet/SchemaConverter.scala
+++ b/sparksql-scalapb/src/main/scala/scalapb/parquet/SchemaConverter.scala
@@ -55,14 +55,14 @@ object SchemaConverter {
     (Option(originalType), repetition) match {
       case (None, Type.Repetition.REPEATED) =>
         builder
-          .group(Type.Repetition.REQUIRED).as(OriginalType.LIST)
+          .group(Type.Repetition.OPTIONAL).as(OriginalType.LIST)
           .group(Type.Repetition.REPEATED)
           .primitive(primitiveType,Type.Repetition.REQUIRED)
           .named("element")
           .named("list")
       case (Some(oType), Type.Repetition.REPEATED) =>
         builder
-          .group(Type.Repetition.REQUIRED).as(OriginalType.LIST)
+          .group(Type.Repetition.OPTIONAL).as(OriginalType.LIST)
           .group(Type.Repetition.REPEATED)
           .primitive(primitiveType,Type.Repetition.REQUIRED).as(oType)
           .named("element")


### PR DESCRIPTION
Add reading and writing support to [Hive](https://github.com/apache/hive) or other tools that use [parquet list](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists) struture.

Given the following protobuf schema:
`
message ListOfPrimitives {
    repeated int64 my_repeated_id = 1;
}
`

Old parquet schema was:
`
message ListOfPrimitives {
  repeated int64 my_repeated_id = 1;
}
`

New parquet schema is:
`
message ListOfPrimitives {
  required group my_repeated_id (LIST) = 1 {
    repeated group list {
      required int64 element;
    }
  }
}
`