### PR TITLE
To bring ScalPBReadSupport par with parquet-proto ProtoReadSupport

### DIFF
--- a/sparksql-scalapb/src/main/scala/scalapb/parquet/ScalaPBReadSupport.scala
+++ b/sparksql-scalapb/src/main/scala/scalapb/parquet/ScalaPBReadSupport.scala
@@ -4,18 +4,28 @@ import java.util
 
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.Log
 import org.apache.parquet.hadoop.api.{InitContext, ReadSupport}
 import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
 import org.apache.parquet.io.api.{GroupConverter, RecordMaterializer}
 import org.apache.parquet.schema.MessageType
 
 class ScalaPBReadSupport[T <: GeneratedMessage with Message[T]] extends ReadSupport[T] {
+  val log = Log.getLog(this.getClass)
+
   override def prepareForRead(
     configuration: Configuration,
     keyValueMetaData: util.Map[String, String],
     fileSchema: MessageType,
     readContext: ReadContext): RecordMaterializer[T] = {
-    val protoClass = Option(keyValueMetaData.get(ScalaPBReadSupport.PB_CLASS)).getOrElse(throw new RuntimeException(s"Value for ${ScalaPBReadSupport.PB_CLASS} not found."))
+
+    val headerScalaPBClass = Option(keyValueMetaData.get(ScalaPBReadSupport.PB_CLASS))
+    val configuredScalaPBClass = Option(configuration.get(ScalaPBReadSupport.PB_CLASS))
+
+    val protoClass = headerScalaPBClass.orElse(configuredScalaPBClass)
+      .getOrElse(throw new RuntimeException(s"Value for ${ScalaPBReadSupport.PB_CLASS} not found."))
+    log.debug("Reading data with ScalaPB class " + protoClass)
+
     val cmp = {
       import scala.reflect.runtime.universe
 
@@ -29,7 +39,7 @@ class ScalaPBReadSupport[T <: GeneratedMessage with Message[T]] extends ReadSupp
     }
 
     new RecordMaterializer[T] {
-      val root = new ProtoMessageConverter[T](cmp, fileSchema, onEnd = _ => ())
+      val root = new ProtoMessageConverter[T](cmp, readContext.getRequestedSchema, onEnd = _ => ())
 
       override def getRootConverter: GroupConverter = root
 
@@ -38,10 +48,35 @@ class ScalaPBReadSupport[T <: GeneratedMessage with Message[T]] extends ReadSupp
   }
 
   override def init(context: InitContext): ReadContext = {
-    new ReadContext(context.getFileSchema)
+    val schema = Option(context.getConfiguration.get(ScalaPBReadSupport.PB_REQUESTED_PROJECTION))
+      .filterNot(_.trim.isEmpty) match {
+      case Some(requestedProjectionString) =>
+        log.info("Reading data with projection " + requestedProjectionString)
+        ReadSupport.getSchemaForRead(context.getFileSchema, requestedProjectionString)
+      case None =>
+        log.info("Reading data with scheme " + context.getFileSchema)
+        context.getFileSchema
+    }
+
+    new ReadContext(schema)
   }
 }
 
 object ScalaPBReadSupport {
   val PB_CLASS = "parquet.scalapb.class"
+  val PB_REQUESTED_PROJECTION = "parquet.scalapb.projection"
+
+  def setRequestedProjection(configuration: Configuration, requestedProjection: String): Unit = {
+    configuration.set(PB_REQUESTED_PROJECTION, requestedProjection)
+  }
+
+  /**
+    * Set name of ScalaPB class to be used for reading data.
+    * If no class is set, value from file header is used.
+    * Note that the value in header is present only if the file was written
+    * using [[scalapb.parquet.ScalaPBWriteSupport ScalaPBWriteSupport]] project, it will fail otherwise.
+    **/
+  def setScalaPBClass(configuration: Configuration, protobufClass: String): Unit = {
+    configuration.set(PB_CLASS, protobufClass)
+  }
 }


### PR DESCRIPTION
This MR resolves #12, resolves #13 

In this MR two methods were added to companion object of `ReadSupport` impl. `ScalaPBReadSupport`
- `scalapb.parquet.ScalaPBReadSupport.setScalaPBClass`
- `scalapb.parquet.ScalaPBReadSupport.setRequestedProjection`

Also some plumbing was modified per parquet-mr protobuf/avro to better reflect parquet-mr api usage.

How to use:
```scala
def readParquetAsRDD[T <: GeneratedMessage with Message[T]](inputDirs: Iterable[String],
                                                          projection: String,
                                                          maybeFilteringBinaryColumn: Option[BinaryColumn],
                                                          job: Job)(implicit tag: ClassTag[T]): RDD[(Void, T)] = {
    val vClass = tag.runtimeClass.asInstanceOf[Class[T]]
    val jobConf = new JobConf(spark.sparkContext.hadoopConfiguration)

    scalapb.parquet.ScalaPBReadSupport.setScalaPBClass(jobConf, vClass.getName)
    scalapb.parquet.ScalaPBReadSupport.setRequestedProjection(jobConf, projection)
    ParquetInputFormat.setReadSupportClass(jobConf, classOf[scalapb.parquet.ScalaPBReadSupport[T]])
    // Set a predicate and Parquet only de serializes the right ones ...
    maybeFilteringBinaryColumn.foreach(bc => {
      val filter = FilterApi.userDefined(bc, classOf[NotNullNotEmptyPredicate])
      ParquetInputFormat.setFilterPredicate(job.getConfiguration, filter)
    })

    val filteredRDD = spark.sparkContext.newAPIHadoopFile(inputDirs.mkString(","), classOf[ScalaPBInputFormat[T]], classOf[Void], vClass, jobConf)

    filteredRDD
  }
```

Unfortunately I did not have time to add any tests even though I have tested this change in my own project I work on currently and it works as expected.

Hopes this helps.