### PR TITLE
Add test for parseFrom message with nested extension

### DIFF
--- a/sparksql-scalapb/src/test/protobuf/extensions.proto
+++ b/sparksql-scalapb/src/test/protobuf/extensions.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+
+option java_package = "com.example.protos";
+
+message Foo {
+  optional string name = 1;
+
+  extensions 100 to 199;
+}
+
+message Baz {
+  extend Foo {
+    optional int32 bar = 126;
+  }
+
+  optional int32 id = 1;
+}

--- a/sparksql-scalapb/src/test/scala/ExtensionsSpec.scala
+++ b/sparksql-scalapb/src/test/scala/ExtensionsSpec.scala
@@ -1,0 +1,31 @@
+package scalapb.spark
+
+import com.example.protos.extensions._
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.col
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalapb.spark.Implicits._
+
+class ExtensionsSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  val spark: SparkSession = SparkSession
+    .builder()
+    .appName("ScalaPB Demo")
+    .master("local[2]")
+    .getOrCreate()
+
+  "Creating Dataset from message with nested extension" should "work" in {
+    val data = Seq(
+      Baz(id = Some(1)),
+      Baz(id = Some(2)),
+      Baz(id = Some(3)),
+    )
+
+    val binaryDS = spark.createDataset(data.map(_.toByteArray))
+    binaryDS.show()
+
+    val protosDS = binaryDS.map(Baz.parseFrom(_))
+    protosDS.show()
+  }
+}


### PR DESCRIPTION
Add a (failing) test for using `parseFrom` for creating a Dataset from serialized messages where the message definition includes a [nested extension](https://developers.google.com/protocol-buffers/docs/proto#nested-exts). This test currently fails with

```
[info] ExtensionsSpec:
[info] Creating Dataset from message with nested extension
[info] - should work *** FAILED ***
[info]   org.apache.spark.SparkException: Task not serializable
...
[info]   Cause: java.io.NotSerializableException: scalapb.lenses.Lens$$anon$1
[info] Serialization stack:
[info]  - object not serializable (class: scalapb.lenses.Lens$$anon$1, value: scalapb.lenses.Lens$$anon$1@2efd8702)
[info]  - field (class: scalapb.GeneratedExtension, name: lens, type: interface scalapb.lenses.Lens)
[info]  - object (class scalapb.GeneratedExtension, GeneratedExtension(scalapb.lenses.Lens$$anon$1@2efd8702))
[info]  - field (class: com.example.protos.extensions.Baz$, name: bar, type: class scalapb.GeneratedExtension)
[info]  - object (class com.example.protos.extensions.Baz$, com.example.protos.extensions.Baz$@628905ca)
```