### PR TITLE
fix warning. add explicit type

### DIFF
--- a/sparksql-scalapb/src/main/scala/scalapb/spark/TypedEncoders.scala
+++ b/sparksql-scalapb/src/main/scala/scalapb/spark/TypedEncoders.scala
@@ -110,7 +110,8 @@ trait Implicits {
       ct: ClassTag[T]
   ): TypedEncoder[T] = new typedEncoders.EnumTypedEncoder[T]
 
-  implicit def byteStringTypedEncoder = typedEncoders.ByteStringTypedEncoder
+  implicit def byteStringTypedEncoder: TypedEncoder[ByteString] =
+    typedEncoders.ByteStringTypedEncoder
 
   implicit def typedEncoderToEncoder[T: ClassTag](implicit
       ev: TypedEncoder[T]


### PR DESCRIPTION
```
[warn] /home/runner/work/sparksql-scalapb/sparksql-scalapb/sparksql-scalapb/src/main/scala/scalapb/spark/TypedEncoders.scala:113:16: Implicit definition should have explicit type (inferred Implicits.this.typedEncoders.ByteStringTypedEncoder.type)
[warn]   implicit def byteStringTypedEncoder = typedEncoders.ByteStringTypedEncoder
[warn]                ^
```